### PR TITLE
允许MSVC 16.9以上编译

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,28 @@ cmake_minimum_required(VERSION 3.16)
 project(kuiper_infer)
 set(CMAKE_CXX_STANDARD 17)
 include_directories(./include)
-
+if (MSVC)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    # 假如编译x64，那么SSE2永远可用
+    # 假如编译x86，那么SSE2可用的话，就开启SSE2
+    if (CMAKE_SIZEOF_VOID_P EQUAL 4)
+        # check if SSE2 is available
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag("/arch:SSE2" HAS_SSE2)
+    else()
+        set(HAS_SSE2 ON)
+    endif()
+    if (HAS_SSE2)
+        # set __SSE2__ and __XOP__ macros
+        add_definitions(-D__SSE2__ -D__XOP__)
+    endif()
+endif()
 option(USE_CUDA "Support Cuda Backend")
 option(BUILD_DEMO "Build The Demo Project" )
 
-set(USE_CUDA ON)
+if (!MSVC)
+    set(USE_CUDA ON)
+endif()
 set(BUILD_DEMO ON)
 
 if (BUILD_DEMO)
@@ -23,6 +40,8 @@ find_package(benchmark REQUIRED)
 find_package(OpenMP REQUIRED)
 find_package(Armadillo REQUIRED)
 find_package(glog REQUIRED)
+find_package(BLAS REQUIRED)
+find_package(LAPACK REQUIRED)
 
 aux_source_directory(./source/data DIR_DATA)
 aux_source_directory(./source/runtime DIR_PARSER)
@@ -31,9 +50,12 @@ aux_source_directory(./source/layer/details DIR_BINOCULAR_LAYER)
 aux_source_directory(./source/parser DIR_PARSER)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
+set(link_lib glog::glog)
+IF (!WIN32)
+    set(link_lib ${link_lib} pthread)
+ENDIF()
 
-set(link_lib glog::glog pthread)
-set(link_math_lib ${ARMADILLO_LIBRARIES} blas lapack)
+set(link_math_lib ${ARMADILLO_LIBRARIES} ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 
 add_library(kuiper SHARED ${DIR_DATA} ${DIR_PARSER} ${DIR_ABSTRACT_LAYER} ${DIR_BINOCULAR_LAYER} ${DIR_PARSER} source/layer/details/platform.hpp)
 target_link_libraries(kuiper ${link_lib} ${link_math_lib} OpenMP::OpenMP_CXX)
@@ -43,6 +65,8 @@ target_include_directories(kuiper PUBLIC ${glog_INCLUDE_DIR})
 target_include_directories(kuiper PUBLIC ${GTest_INCLUDE_DIR})
 target_include_directories(kuiper PUBLIC ${Armadillo_INCLUDE_DIR})
 
+# mathfun library defines
+add_compile_definitions(SSE_MATHFUN_WITH_CODE USE_SSE_AUTO)
 
 enable_testing()
 add_subdirectory(bench)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -5,11 +5,23 @@ set(link_lib benchmark::benchmark benchmark::benchmark_main)
 
 add_executable(bench_kuiper ${DIR_BENCH})
 target_link_directories(bench_kuiper PUBLIC ${PROJECT_SOURCE_DIR}/lib)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fopenmp -march=native")
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /O2 /openmp:llvm")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fopenmp -march=native")
+endif()
 
 target_link_directories(bench_kuiper PUBLIC ${PROJECT_SOURCE_DIR}/lib)
 target_link_libraries(bench_kuiper ${link_lib} OpenMP::OpenMP_CXX)
 target_link_libraries(bench_kuiper kuiper)
+
+if (MSVC)
+    # find kuiper dll
+    add_custom_command(TARGET bench_kuiper POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_FILE_DIR:kuiper>/kuiper.dll"
+            $<TARGET_FILE_DIR:bench_kuiper>)
+endif()
 
 target_include_directories(bench_kuiper PUBLIC ${benchmark_INCLUDE_DIRS})
 target_include_directories(bench_kuiper PUBLIC ${glog_INCLUDE_DIR})

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -7,9 +7,20 @@ include_directories(${OpenCV_INCLUDE_DIRS})
 link_directories(${OpenCV_LIBRARY_DIRS})
 
 aux_source_directory(../demos DIR_DEMOS)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fopenmp -march=native")
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /O2 /openmp:llvm")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fopenmp -march=native")
+endif()
 
 add_executable(yolo_test ${DIR_DEMOS} image_util.hpp image_util.cpp)
 target_include_directories(yolo_test PUBLIC ../include)
 target_link_directories(yolo_test PUBLIC ${PROJECT_SOURCE_DIR}/lib)
 target_link_libraries(yolo_test ${OpenCV_LIBS} kuiper)
+
+if (MSVC)
+    add_custom_command(TARGET yolo_test POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_FILE_DIR:kuiper>/kuiper.dll"
+            $<TARGET_FILE_DIR:yolo_test>)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,20 +2,36 @@ find_package(GTest REQUIRED)
 find_package(OpenMP REQUIRED)
 find_package(glog REQUIRED)
 find_package(Armadillo REQUIRED)
+find_package(BLAS REQUIRED)
+find_package(LAPACK REQUIRED)
 
 aux_source_directory(../test DIR_TEST)
 
-set(link_lib glog::glog pthread GTest::gtest)
-set(link_math_lib ${ARMADILLO_LIBRARIES} blas lapack)
+set(link_lib glog::glog GTest::gtest)
+if(!WIN32)
+    set(link_lib "${link_lib} pthread")
+endif()
+set(link_math_lib ${ARMADILLO_LIBRARIES} ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 
 add_executable(test_kuiper ${DIR_TEST})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -fopenmp -march=native")
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /O0 /openmp:llvm")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -fopenmp -march=native")
+endif()
 
 target_link_libraries(test_kuiper ${link_lib} ${link_math_lib})
 target_link_libraries(test_kuiper OpenMP::OpenMP_CXX)
 
 target_link_directories(test_kuiper PUBLIC ${PROJECT_SOURCE_DIR}/lib)
 target_link_libraries(test_kuiper kuiper)
+
+if (MSVC)
+    add_custom_command(TARGET test_kuiper POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_FILE_DIR:kuiper>/kuiper.dll"
+            $<TARGET_FILE_DIR:test_kuiper>)
+endif()
 
 target_include_directories(test_kuiper PUBLIC ${glog_INCLUDE_DIR})
 target_include_directories(test_kuiper PUBLIC ${GTest_INCLUDE_DIR})


### PR DESCRIPTION
使用find_package函数寻找BLAS和LAPACK。在Windows上去掉不需要的pthread。用编译器旗标/arch:SSE2测试SSE2支持，补上MSVC缺少的__SSE2__和__XOP__。用/openmp:llvm补偿原版openmp缺少特性（需要版本16.9以上）。目前不支持CUDA。