### PR TITLE
头文件递归包含，修改了RuntimeGraph::CreateLayer中的layer类型

### DIFF
--- a/include/runtime/runtime_op.hpp
+++ b/include/runtime/runtime_op.hpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include "layer/abstract/layer.hpp"
+// #include "layer/abstract/layer.hpp"
 #include "runtime/ir.h"
 #include "runtime_attr.hpp"
 #include "runtime_operand.hpp"

--- a/source/runtime/runtime_ir.cpp
+++ b/source/runtime/runtime_ir.cpp
@@ -218,7 +218,7 @@ std::vector<std::shared_ptr<Tensor<float>>> RuntimeGraph::Forward(
 std::shared_ptr<Layer> RuntimeGraph::CreateLayer(
     const std::shared_ptr<RuntimeOperator>& op) {
   LOG_IF(FATAL, !op) << "Operator is empty!";
-  const auto& layer = LayerRegisterer::CreateLayer(op);
+  auto layer = LayerRegisterer::CreateLayer(op);
   LOG_IF(FATAL, !layer) << "Layer init failed " << op->type;
   return layer;
 }


### PR DESCRIPTION
注释掉runtime_op.hpp中的layer.hpp可以防止头文件递归包含导致的编译问题。LayerRegisterer::CreateLayer是按值返回layer，无需const &。