### PR TITLE
operators_maps for all ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 .vscode/
 
 .idea/
+.cache/
 
 output0.jpg
 

--- a/include/runtime/runtime_ir.hpp
+++ b/include/runtime/runtime_ir.hpp
@@ -152,10 +152,12 @@ class RuntimeGraph {
   std::string output_name_;  /// 计算图输出节点的名称
   std::string param_path_;   /// 计算图的结构文件
   std::string bin_path_;     /// 计算图的权重文件
+  //   std::map<std::string, std::shared_ptr<RuntimeOperator>>
+  //       input_operators_maps_;  /// 保存输入节点
+  //   std::map<std::string, std::shared_ptr<RuntimeOperator>>
+  //       output_operators_maps_;  /// 保存输出节点
   std::map<std::string, std::shared_ptr<RuntimeOperator>>
-      input_operators_maps_;  /// 保存输入节点
-  std::map<std::string, std::shared_ptr<RuntimeOperator>>
-      output_operators_maps_;  /// 保存输出节点
+      operators_maps_;  /// 保存所有节点，根据唯一的name索引
   std::vector<std::shared_ptr<RuntimeOperator>> topo_operators_;
   std::vector<std::shared_ptr<RuntimeOperator>>
       operators_;                       /// 计算图的计算节点


### PR DESCRIPTION
* 所有的operators以<name, op>的map存储，构建图关系时，不用再遍历整个operators，以及std::find(name)，根据output_names直接插入map中存储的节点。
* 这样去掉了input_operators_maps和ioutput_operators_maps，需要他们时，用op->type进行区分
* 修改后运行了yolo_test，能够正确识别