### PR TITLE
Modified the Forward() interface of the Expression Layer to use Prefix Expressions to evaluate values instead of Postfix Expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@
 - [superCB](https://github.com/SuperCB)
 - [sanbuphy](https://github.com/sanbuphy)
 - [TypeFloat](https://github.com/TypeFloat)
+- [Jasmine-up](https://github.com/Jasmine-up)
 
 ### 如何参与项目贡献？
 1. 提交代码增加新功能或修改bug；

--- a/source/layer/details/expression.cpp
+++ b/source/layer/details/expression.cpp
@@ -54,36 +54,39 @@ StatusCode ExpressionLayer::Forward(
 
   const uint32_t batch_size = outputs.size();
   std::stack<std::vector<std::shared_ptr<Tensor<float>>>> op_stack;
-  const std::vector<std::shared_ptr<TokenNode>>& token_nodes =
-      this->parser_->Generate();
-  for (const auto& token_node : token_nodes) {
-    if (token_node->num_index >= 0) {
-      // process operator
-      uint32_t start_pos = token_node->num_index * batch_size;
+  for (int index = expressions.size() - 1; index >= 0; index--) {
+    const auto current_token = expressions.at(index);
+    // 如果是数据类型，就将对应分支的input插入到栈中
+    if (current_token.token_type == TokenType::TokenInputNumber) {
+      uint32_t start_pos = current_token.start_pos + 1;
+      uint32_t end_pos = current_token.end_pos;
+      CHECK(end_pos > start_pos || end_pos <= this->statement_.length())
+          << "Current token has a wrong length";
+      const std::string& str_number =
+          std::string(this->statement_.begin() + start_pos,
+                      this->statement_.begin() + end_pos);
+      int32_t input_branch = std::stoi(str_number);
+      CHECK(input_branch >= 0) << "Input branch must be >= 0";
+      uint32_t input_start_pos = input_branch * batch_size;
       std::vector<std::shared_ptr<Tensor<float>>> input_token_nodes;
       for (uint32_t i = 0; i < batch_size; ++i) {
-        CHECK(i + start_pos < inputs.size())
+        CHECK(i + input_start_pos < inputs.size())
             << "The " << i
             << "th operand doesn't have appropriate number of tensors";
         // fixme 这里的张量拷贝是否有必要
-        input_token_nodes.push_back(inputs.at(i + start_pos));
+        input_token_nodes.push_back(inputs.at(i + input_start_pos));
       }
       op_stack.push(input_token_nodes);
-    } else {
+    } else if (current_token.token_type == TokenType::TokenAdd ||
+               current_token.token_type == TokenType::TokenMul) {
       // process operation
-      const int32_t op = token_node->num_index;
-      if (op != int(TokenType::TokenAdd) && op != int(TokenType::TokenMul)) {
-        LOG(FATAL) << "Unknown operator type: " << op;
-      }
       CHECK(op_stack.size() >= 2) << "The number of operand is less than two";
       std::vector<std::shared_ptr<Tensor<float>>> input_node1 = op_stack.top();
-
       CHECK(input_node1.size() == batch_size)
           << "The first operand doesn't have appropriate number of tensors, "
              "which need "
           << batch_size;
       op_stack.pop();
-
       std::vector<std::shared_ptr<Tensor<float>>> input_node2 = op_stack.top();
       CHECK(input_node2.size() == batch_size)
           << "The second operand doesn't have appropriate number of tensors, "
@@ -93,23 +96,24 @@ StatusCode ExpressionLayer::Forward(
 
       std::vector<std::shared_ptr<Tensor<float>>> output_token_nodes(
           batch_size);
+      if (current_token.token_type == TokenType::TokenAdd) {
 #pragma omp parallel for num_threads(batch_size)
-      for (uint32_t i = 0; i < batch_size; ++i) {
-        // do execution
-        if (op == int(TokenType::TokenAdd)) {
+        for (uint32_t i = 0; i < batch_size; ++i) {
           output_token_nodes.at(i) =
               TensorElementAdd(input_node1.at(i), input_node2.at(i));
-        } else if (op == int(TokenType::TokenMul)) {
+        }
+      } else {
+#pragma omp parallel for num_threads(batch_size)
+        for (uint32_t i = 0; i < batch_size; ++i) {
           output_token_nodes.at(i) =
               TensorElementMultiply(input_node1.at(i), input_node2.at(i));
-        } else {
-          LOG(FATAL) << "Unknown operator type: " << op;
         }
       }
       op_stack.push(output_token_nodes);
+    } else {
+      continue;
     }
   }
-
   CHECK(op_stack.size() == 1)
       << "The expression has more than one output operand!";
   std::vector<sftensor> output_node = op_stack.top();

--- a/source/layer/details/expression.cpp
+++ b/source/layer/details/expression.cpp
@@ -52,7 +52,10 @@ StatusCode ExpressionLayer::Forward(
   CHECK(!expressions.empty())
       << "The expression parser failed to parse " << statement_;
 
-  const uint32_t batch_size = outputs.size();
+  statement_.erase(std::remove_if(statement_.begin(), statement_.end(),
+                                  [](char c) { return std::isspace(c); }),
+                   statement_.end());
+  const uint32_t batch_size = outputs.size();  
   std::stack<std::vector<std::shared_ptr<Tensor<float>>>> op_stack;
   for (int index = expressions.size() - 1; index >= 0; index--) {
     const auto current_token = expressions.at(index);


### PR DESCRIPTION
更改前后对比：
前：对抽象表达式进行词法语法解析，生成语法树，根据语法树得到逆波兰表达式也就是后缀表达式，最后根据后缀表达式计算抽象表达式的值。
后：对抽象表达式进行词法解析，根据词法解析结果也就是前缀表达式计算抽象表达式的值。

分析：操作更少，时间复杂度更低。

测试：已经在Resnet和Yolo上测试，输出结果与原来的输出结果一致。