### PR TITLE
最近邻上采样算子中，在内层循环中没有必要判断目标位置的列数与行数是否小于目标图像的宽和高

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@
 - [TypeFloat](https://github.com/TypeFloat)
 - [Jasmine-up](https://github.com/Jasmine-up)
 - [PerrySkywalker](https://github.com/PerrySkywalker)
+- [delve-wang](https://github.com/delve-wang)
 
 ### 如何参与项目贡献？
 1. 提交代码增加新功能或修改bug；

--- a/source/layer/details/upsample.cpp
+++ b/source/layer/details/upsample.cpp
@@ -122,18 +122,13 @@ StatusCode UpSampleLayer::Forward(const std::vector<std::shared_ptr<Tensor<float
             const uint32_t dest_w = w * scale_w;
             const float* input_col_ptr = input_channel.colptr(w);
             for (uint32_t sw = 0; sw < scale_w; ++sw) {
-              if (dest_w + sw >= output_w) {
-                continue;
-              }
               float* output_col_ptr = output_channel.colptr(dest_w + sw);
               for (uint32_t h = 0; h < input_h; ++h) {
                 const uint32_t dest_h = h * scale_h;
                 float* output_ptr = output_col_ptr + dest_h;
                 const float input_value = *(input_col_ptr + h);
                 for (uint32_t sh = 0; sh < scale_h; ++sh) {
-                  if (dest_h + sh < output_h) {
-                    *(output_ptr + sh) = input_value;
-                  }
+                  *(output_ptr + sh) = input_value;
                 }
               }
             }


### PR DESCRIPTION
最近邻上采样算子中，在内层循环中没有必要判断目标位置的列数与行数是否小于目标图像的宽和高，按照代码逻辑，以上两个条件是必然成立的